### PR TITLE
feat: waybar replace i3status-rs

### DIFF
--- a/homes/sway.nix
+++ b/homes/sway.nix
@@ -17,13 +17,13 @@ let
     then
       area=$(slurp)
       wf-recorder -g "$area" $args -f ~/Screenshots/$(date +'recording_%Y-%m-%d-%H%M%S.mp4') -c h264_vaapi -d /dev/dri/renderD128 >/dev/null 2>&1 &
-      notify-send "Recording started"
-      pkill -RTMIN+8 i3status-rs
+      pkill -SIGUSR1 waybar
     else
       killall -s SIGINT wf-recorder
       notify-send "Recording stopped"
       wait $(pgrep wf-recorder)
-      pkill -RTMIN+8 i3status-rs
+      swaymsg bar bar-0 mode dock
+      pkill -SIGUSR1 waybar
     fi;
   '';
   bookmarks = pkgs.writeShellScript "bookmarks" ''
@@ -85,48 +85,7 @@ in
       "Mod4+Control+l" = "exec loginctl lock-session";
     };
     inherit fonts;
-    bars = [
-      {
-        mode = "dock";
-        hiddenState = "hide";
-        position = "bottom";
-        inherit fonts;
-        workspaceButtons = true;
-        workspaceNumbers = true;
-        statusCommand = "i3status-rs ~/.config/i3status-rust/config-bottom.toml";
-        trayOutput = "primary";
-        colors = {
-          background = "#2E3440";
-          statusline = "#839496";
-          separator = "#777777";
-          focusedWorkspace = {
-            border = "#4C7899";
-            background = "#285577";
-            text = "#D8DEE9";
-          };
-          activeWorkspace = {
-            border = "#333333";
-            background = "#4C7899";
-            text = "#D8DEE9";
-          };
-          inactiveWorkspace = {
-            border = "#3B4252";
-            background = "#2E3440";
-            text = "#888888";
-          };
-          urgentWorkspace = {
-            border = "#2F343A";
-            background = "#900000";
-            text = "#D8DEE9";
-          };
-          bindingMode = {
-            border = "#2F343A";
-            background = "#900000";
-            text = "#D8DEE9";
-          };
-        };
-      }
-    ];
+    bars = [ ];
     startup = [
       {
         command = ''

--- a/homes/waybar.nix
+++ b/homes/waybar.nix
@@ -1,0 +1,151 @@
+{ pkgs, ... }:
+{
+  programs.waybar = {
+    enable = true;
+    systemd.enable = true;
+    settings = {
+      mainBar = {
+        layer = "top";
+        position = "bottom";
+        height = 20;
+        font-size = 9;
+        modules-left = [
+          "sway/workspaces"
+        ];
+        modules-center = [
+          "custom/notification"
+          "custom/recording"
+        ];
+        modules-right = [
+          "idle_inhibitor"
+          "pulseaudio"
+          "pulseaudio#mic"
+          "group/network"
+          "cpu"
+          "memory"
+          "temperature"
+          "battery"
+          "clock"
+          "tray"
+        ];
+        tray = {
+          spacing = 8;
+          show-passive-items = true;
+        };
+        "custom/recording" = {
+          exec = ''
+            pgrep wf-recorder >/dev/null && echo " REC ●" || echo ""
+          '';
+          interval = 1;
+          format = "{}";
+          hide-on-empty = true;
+          tooltip = false;
+          on-click = null;
+        };
+        idle_inhibitor = {
+          format = "{icon}";
+          format-icons = {
+            activated = " ";
+            deactivated = " ";
+          };
+        };
+        pulseaudio = {
+          format = "{icon} {volume}%";
+          format-bluetooth = "{volume}% {icon}";
+          format-bluetooth-muted = " {icon}";
+          format-muted = "󰖁 ";
+          format-icons = {
+            headphone = "";
+            default = [
+              ""
+              ""
+              ""
+            ];
+          };
+          scroll-step = 5;
+          on-click = "${pkgs.wireplumber}/bin/wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+          on-click-right = "${pkgs.pavucontrol}/bin/pavucontrol";
+        };
+        "pulseaudio#mic" = {
+          format = "{format_source}";
+          format-source = " {volume}%";
+          format-source-muted = "";
+          on-click = "${pkgs.wireplumber}/bin/wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle";
+          on-click-right = "${pkgs.pavucontrol}/bin/pavucontrol";
+          on-scroll-up = "${pkgs.wireplumber}/bin/wpctl set-volume -l 1.5 @DEFAULT_AUDIO_SOURCE@ 5%+";
+          on-scroll-down = "${pkgs.wireplumber}/bin/wpctl set-volume @DEFAULT_AUDIO_SOURCE@ 5%-";
+          scroll-step = 5;
+          tooltip = false;
+        };
+        "group/network" = {
+          modules = [
+            "network"
+            "network#wireguard"
+          ];
+          orientation = "inherit";
+        };
+        network = {
+          format-disconnected = "";
+          format-ethernet = "󰈀 ";
+          format-wifi = "{icon} {essid}";
+          format-icons = [
+            "󰤟 "
+            "󰤢 "
+            "󰤥 "
+            "󰤨 "
+          ];
+          tooltip-format = "{ifname}\n{ipaddr}\n{essid} ({signalStrength}%)";
+          on-click = "alacritty --command nmtui";
+        };
+        "network#wireguard" = {
+          interface = "wg0";
+          interval = 3;
+          format-disabled = "◍";
+          format = "◉";
+          tooltip-format = "Wireguard IP:{ipaddr} GW:{gwaddr} NM:{netmask} {bandwidthDownBytes} {bandwidthUpBytes}";
+          tooltip-format-disabled = "▾ Wireguard down.";
+        };
+        cpu = {
+          format = " {usage:>2}% {max_frequency}GHz";
+        };
+        memory = {
+          format = " {used:0.1f}GB";
+          tooltip-format = "{used:0.1f}GiB used, {swapUsed:0.1f}GiB swap";
+        };
+        clock = {
+          format = "{:%I:%M %p}";
+          tooltip-format = "<tt><small>{calendar}</small></tt>";
+          calendar = {
+            format = {
+              months = "<span color='#ffead3'><b>{}</b></span>";
+              weekdays = "<span color='#ffcc66'><b>{}</b></span>";
+              today = "<span color='#ff6699'><b>{}</b></span>";
+            };
+          };
+          actions = {
+            "on-scroll-up" = "shift_up";
+            "on-scroll-down" = "shift_down";
+          };
+        };
+        "custom/notification" = {
+          exec = "${pkgs.swaynotificationcenter}/bin/swaync-client -swb";
+          return-type = "json";
+          format = " {icon} ";
+          on-click = "${pkgs.swaynotificationcenter}/bin/swaync-client -t -sw";
+          on-click-right = "${pkgs.swaynotificationcenter}/bin/swaync-client -d -sw";
+          escape = true;
+          format-icons = {
+            notification = "󰂚";
+            none = "󰂜";
+            dnd-notification = "󰂛";
+            dnd-none = "󰪑";
+            inhibited-notification = "󰂛";
+            inhibited-none = "󰪑";
+            dnd-inhibited-notification = "󰂛";
+            dnd-inhibited-none = "󰪑";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Replaced irstatus-rs with waybar
waybar run like a user service
because of this the configuration must be with the path of executables:
${pkgs.swaynotificationcenter}/bin/swaync-client instead of swaync-client etc