### PR TITLE
fix: rename deprecated options (pulseaudio, opengl)

### DIFF
--- a/modules/hardware/bluetooth.nix
+++ b/modules/hardware/bluetooth.nix
@@ -4,7 +4,7 @@ let cfg = config.hardware.bluetooth;
 in
 {
   config = mkIf cfg.enable {
-    hardware.pulseaudio.package = pkgs.pulseaudioFull;
+    services.pulseaudio.package = pkgs.pulseaudioFull;
     services.blueman.enable = true;
   };
 }

--- a/modules/virtualisation/wine.nix
+++ b/modules/virtualisation/wine.nix
@@ -13,7 +13,7 @@ in
       winePackage
       winetricks
     ];
-    hardware.opengl.driSupport32Bit = true;
-    hardware.pulseaudio.support32Bit = true;
+    hardware.graphics.enable32Bit = true;
+    services.pulseaudio.support32Bit = true;
   };
 }


### PR DESCRIPTION
Renames deprecated NixOS options to their new locations:

- `modules/hardware/bluetooth.nix`: `hardware.pulseaudio.package` → `services.pulseaudio.package`
- `modules/virtualisation/wine.nix`: `hardware.opengl.driSupport32Bit` → `hardware.graphics.enable32Bit`
- `modules/virtualisation/wine.nix`: `hardware.pulseaudio.support32Bit` → `services.pulseaudio.support32Bit`

These silence evaluation warnings on hosts that enable bluetooth and/or wine. No behavior change.