### PR TITLE
fix: replace removed nordic gtk theme with colloid-dark

### DIFF
--- a/homes/gtk.nix
+++ b/homes/gtk.nix
@@ -1,8 +1,8 @@
 { pkgs, ... }: {
   gtk = {
     enable = true;
-    theme = { name = "Nordic"; package = pkgs.nordic; };
-    iconTheme = {name = "Papirus Dark"; package = pkgs.papirus-icon-theme;};
+    theme = { name = "Colloid-Dark"; package = pkgs.colloid-gtk-theme; };
+    iconTheme = { name = "Colloid-Dark"; package = pkgs.colloid-icon-theme; };
   };
 
 }


### PR DESCRIPTION
nordic was removed from nixpkgs (depended on gtk-engine-murrine, which was unmaintained and GTK2-only).

Replaces in homes/gtk.nix:
- gtk theme: pkgs.nordic / "Nordic" -> pkgs.colloid-gtk-theme / "Colloid-Dark"
- icon theme: pkgs.papirus-icon-theme / "Papirus Dark" -> pkgs.colloid-icon-theme / "Colloid-Dark"

Colloid is by the same author (vinceliuice) and ships matching GTK3+GTK4 themes + icon set.